### PR TITLE
rustup: libsyntax changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ fn expand_execute(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
 
     let conn = parser.parse_expr();
 
-    if !parser.eat(&Comma) {
+    if !parser.eat(&Comma).ok().unwrap() {
         cx.span_err(parser.span, "expected `,`");
         return DummyResult::expr(sp);
     }
@@ -92,7 +92,7 @@ fn expand_execute(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
         None => return DummyResult::expr(sp),
     };
 
-    if !parser.eat(&Comma) {
+    if !parser.eat(&Comma).ok().unwrap() {
         cx.span_err(parser.span, "expected `,`");
         return DummyResult::expr(sp);
     }
@@ -143,7 +143,7 @@ fn parse_args(cx: &mut ExtCtxt, parser: &mut Parser) -> Option<Vec<P<Expr>>> {
     while parser.token != Eof {
         args.push(parser.parse_expr());
 
-        if !parser.eat(&Comma) && parser.token != Eof {
+        if !parser.eat(&Comma).ok().unwrap() && parser.token != Eof {
             cx.span_err(parser.span, "expected `,`");
             return None;
         }


### PR DESCRIPTION
(same story as in https://github.com/tomjakubowski/json_macros/pull/16)

This update follows changes in libsyntax by @phildawes to use `Result`
in parsers instead of panicking; however, as I'm not sure what's the
best way to handle errors in syntax extensions, I decided to bring back
the old behavior at the moment and panic on explicit unwrapping of
errors. (Note: `syntax::diagnostic::FatalError` does not implement
`Debug`, so we cannot directly unwrap the `Result`.)