### PR TITLE
Missing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ valid Postgres query.
 
 fn main() {
     let query = sql!("SELECT * FROM users WHERE name = $1");
-    let bad_query = sql!("SELECT * FORM users WHERE name = $1");
+    let bad_query = sql!("SELECT * FORM users WEHRE name = $1");
 }
 ```
 


### PR DESCRIPTION
To match the error message.