### PR TITLE
Replace parse_expr_panic() with parse_expr().unwrap()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ fn expand_sql(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
     let mut parser = parse::new_parser_from_tts(cx.parse_sess(), cx.cfg(),
                                                 tts.to_vec());
 
-    let query_expr = cx.expander().fold_expr(parser.parse_expr_panic());
+    let query_expr = cx.expander().fold_expr(parser.parse_expr().unwrap());
     let query = match parse_str_lit(cx, &*query_expr) {
         Some(query) => query,
         None => return DummyResult::expr(sp)
@@ -77,14 +77,14 @@ fn expand_execute(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
     let mut parser = parse::new_parser_from_tts(cx.parse_sess(), cx.cfg(),
                                                 tts.to_vec());
 
-    let conn = parser.parse_expr_panic();
+    let conn = parser.parse_expr().unwrap();
 
     if !parser.eat(&Comma).ok().unwrap() {
         cx.span_err(parser.span, "expected `,`");
         return DummyResult::expr(sp);
     }
 
-    let query_expr = cx.expander().fold_expr(parser.parse_expr_panic());
+    let query_expr = cx.expander().fold_expr(parser.parse_expr().unwrap());
     let query = match parse_str_lit(cx, &*query_expr) {
         Some(query) => query,
         None => return DummyResult::expr(sp),
@@ -144,7 +144,7 @@ fn parse_args(cx: &mut ExtCtxt, parser: &mut Parser) -> Option<Vec<P<Expr>>> {
     let mut args = Vec::new();
 
     while parser.token != Eof {
-        args.push(parser.parse_expr_panic());
+        args.push(parser.parse_expr().unwrap());
 
         if !parser.eat(&Comma).ok().unwrap() && parser.token != Eof {
             cx.span_err(parser.span, "expected `,`");


### PR DESCRIPTION
This PR makes postgres-macros build on newest nightlies. Breakage caused by rust-lang/rust@44d8abcc0f372dbc7ad58f312303d2e59612dec9. It doesn't seem to me like the `panictry!()` macro in libsyntax provides anything considerably more useful than plain `.unwrap()`, but someone who knows more might want to check.