### PR TITLE
Use plugin API from rustc_plugin crate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,10 @@
 
 extern crate libc;
 extern crate rustc;
+extern crate rustc_plugin;
 extern crate syntax;
 
-use rustc::plugin::Registry;
+use rustc_plugin::Registry;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::str;


### PR DESCRIPTION
In rust-lang/rust@1430a3500076ad504a0b30be77fd2ad4468ea769 the plugin
API has been moved to a separate `rustc_plugin` crate.