### PR TITLE
Update for simplified parser API.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ fn expand_execute(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
 
     let conn = parser.parse_expr().unwrap();
 
-    if !parser.eat(&Comma).ok().unwrap() {
+    if !parser.eat(&Comma) {
         cx.span_err(parser.span, "expected `,`");
         return DummyResult::expr(sp);
     }
@@ -91,7 +91,7 @@ fn expand_execute(cx: &mut ExtCtxt, sp: Span, tts: &[TokenTree])
         None => return DummyResult::expr(sp),
     };
 
-    if parser.token != Eof && !parser.eat(&Comma).ok().unwrap() {
+    if parser.token != Eof && !parser.eat(&Comma) {
         cx.span_err(parser.span, "expected `,`");
         return DummyResult::expr(sp);
     }
@@ -147,7 +147,7 @@ fn parse_args(cx: &mut ExtCtxt, parser: &mut Parser) -> Option<Vec<P<Expr>>> {
     while parser.token != Eof {
         args.push(parser.parse_expr().unwrap());
 
-        if !parser.eat(&Comma).ok().unwrap() && parser.token != Eof {
+        if !parser.eat(&Comma) && parser.token != Eof {
             cx.span_err(parser.span, "expected `,`");
             return None;
         }


### PR DESCRIPTION
The return type of `Parser::eat()` is no longer wrapped in a `Result`.
See rust-lang/rust@9023c659af8a43dd5e284d7b311e5f19721c9bd8 for the
changes in libsyntax.