### PR TITLE
Fix build interrupt breaking subsequent builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ VERSION = 9.4.4
 SOURCE_URL = https://ftp.postgresql.org/pub/source/v$(VERSION)/postgresql-$(VERSION).tar.gz
 
 BUILDDIR ?= $(OUT_DIR)/build
+TMPDIR ?= $(OUT_DIR)/tmp
 POSTGRES_DIR := $(BUILDDIR)/postgresql-$(VERSION)
 CFLAGS ?= -O2 -fPIC -Wall -Wextra
 
@@ -32,8 +33,12 @@ $(POSTGRES_STAMP): $(POSTGRES_DIR)
 	$(MAKE) -C $(POSTGRES_DIR)
 	touch $(POSTGRES_STAMP)
 
-$(POSTGRES_DIR): | $(BUILDDIR)
-	curl $(SOURCE_URL) | tar xzf - -C $(BUILDDIR)
+$(POSTGRES_DIR): | $(TMPDIR) $(BUILDDIR)
+	curl $(SOURCE_URL) | tar xzf - -C $(TMPDIR)
+	mv $(TMPDIR)/* $(BUILDDIR)
 
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
+
+$(TMPDIR):
+	mkdir -p $(TMPDIR)


### PR DESCRIPTION
Much of the time spent compiling is during the postgresql source tarball
download. If the build were interrupted during this process, subsequent
builds would fail since the postgresql source was only partially
downloaded, but the Makefile thought it was.

This patch corrects that behavior by downloading the source to a tmp
folder first. The extracted source is moved to its destination only
after it is completely available.

Resolves #25.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sfackler/rust-postgres-macros/26)
<!-- Reviewable:end -->
